### PR TITLE
Fixed highlighting for access modifiers, new, delete and constexpr

### DIFF
--- a/mode-c_cpp.js
+++ b/mode-c_cpp.js
@@ -64,8 +64,9 @@ var c_cppHighlightRules = function() {
     );
 
     var storageModifiers = (
-        "const|extern|register|restrict|static|volatile|inline|private:|" +
-        "protected:|public:|friend|explicit|virtual|export|mutable|typename"
+        "const|extern|register|restrict|static|volatile|inline|private|" +
+        "protected|public|friend|explicit|virtual|export|mutable|typename|" +
+        "constexpr|new|delete"
     );
 
     var keywordOperators = (


### PR DESCRIPTION
I believe you saw the issue at ajaxorg/ace (because you closed it) so I don't think this pull request needs an explanation.
